### PR TITLE
Fix toolchain build

### DIFF
--- a/toolchain.sh
+++ b/toolchain.sh
@@ -5,6 +5,9 @@
 # $1 = specifies the target architecture
 # $2 = specifies the installation directory
 
+# exit when any command fails
+set -e
+
 BUILDDIR=build
 CLONE_DEPTH="--depth=50"
 PREFIX="$2"
@@ -36,7 +39,7 @@ mv isl-0.15 gcc/isl
 fi
 
 if [ ! -d "hermit" ]; then
-git clone --recursive -b master https://github.com/hermitcore/libhermit-rs.git hermit
+git clone --recursive -b master https://github.com/hermitcore/hermit-playground hermit
 fi
 
 if [ ! -d "newlib" ]; then
@@ -67,7 +70,7 @@ fi
 if [ ! -d "tmp/hermit" ]; then
 mkdir -p tmp/hermit
 cd tmp/hermit
-cmake -DTOOLCHAIN_BIN_DIR=$PREFIX/bin -DCMAKE_INSTALL_PREFIX=$PREFIX -DBOOTSTRAP=true ../../hermit
+cmake -DTOOLCHAIN_BIN_DIR=$PREFIX/bin -DCMAKE_INSTALL_PREFIX=$PREFIX -DBOOTSTRAP=true ../../hermit/
 make hermit-bootstrap
 make hermit-bootstrap-install
 cd -
@@ -87,12 +90,9 @@ cd ..
 if [ ! -d "tmp/gcc" ]; then
 mkdir -p tmp/gcc
 cd tmp/gcc
-../../gcc/configure --target=$TARGET --prefix=$PREFIX --with-newlib --with-isl --disable-multilib --without-libatomic --enable-languages=c,c++,go,fortran,lto --disable-nls --disable-shared --disable-libssp --enable-threads=posix --disable-libgomp --enable-tls --enable-lto --disable-symver && make $NJOBS && make install
+../../gcc/configure --target=$TARGET --prefix=$PREFIX --with-newlib --with-isl --disable-multilib --without-libatomic --enable-languages=c,c++,go,fortran,lto --disable-nls --disable-shared --disable-libssp --enable-threads=posix --enable-libgomp --enable-tls --enable-lto --disable-symver && make $NJOBS && make install
 cd -
 fi
-
-# workaroud, compiler needs libgomp.spec to support OpenMP
-install -m 644 hermit/usr/libomp/libgomp.spec $PREFIX/$TARGET/lib
 
 if [ ! -d "tmp/final" ]; then
 mkdir -p tmp/final

--- a/toolchain.sh
+++ b/toolchain.sh
@@ -56,14 +56,18 @@ fi
 if [ ! -d "tmp/binutils" ]; then
 mkdir -p tmp/binutils
 cd tmp/binutils
-../../binutils/configure --target=$TARGET --prefix=$PREFIX --with-sysroot --disable-multilib --disable-shared --disable-nls --disable-gdb --disable-libdecnumber --disable-readline --disable-sim --disable-libssp --enable-tls --enable-lto --enable-plugin && make $NJOBS && make install
+../../binutils/configure --target=$TARGET --prefix=$PREFIX --with-sysroot --disable-multilib --disable-shared --disable-nls --disable-gdb --disable-libdecnumber --disable-readline --disable-sim --disable-libssp --enable-tls --enable-lto --enable-plugin
+make $NJOBS
+make install
 cd -
 fi
 
 if [ ! -d "tmp/bootstrap" ]; then
 mkdir -p tmp/bootstrap
 cd tmp/bootstrap
-../../gcc/configure --target=$TARGET --prefix=$PREFIX --without-headers --disable-multilib --with-isl --enable-languages=c,c++,lto --disable-nls --disable-shared --disable-libssp --disable-libgomp --enable-threads=posix --enable-tls --enable-lto --disable-symvers && make $NJOBS all-gcc && make install-gcc
+../../gcc/configure --target=$TARGET --prefix=$PREFIX --without-headers --disable-multilib --with-isl --enable-languages=c,c++,lto --disable-nls --disable-shared --disable-libssp --disable-libgomp --enable-threads=posix --enable-tls --enable-lto --disable-symvers
+make $NJOBS all-gcc
+make install-gcc
 cd -
 fi
 
@@ -79,7 +83,9 @@ fi
 if [ ! -d "tmp/newlib" ]; then
 mkdir -p tmp/newlib
 cd tmp/newlib
-../../newlib/configure --target=$TARGET --prefix=$PREFIX --disable-shared --disable-multilib --enable-lto --enable-newlib-hw-fp --enable-newlib-io-c99-formats --enable-newlib-multithread && make $NJOBS && make install
+../../newlib/configure --target=$TARGET --prefix=$PREFIX --disable-shared --disable-multilib --enable-lto --enable-newlib-hw-fp --enable-newlib-io-c99-formats --enable-newlib-multithread
+make $NJOBS
+make install
 cd -
 fi
 
@@ -90,7 +96,9 @@ cd ..
 if [ ! -d "tmp/gcc" ]; then
 mkdir -p tmp/gcc
 cd tmp/gcc
-../../gcc/configure --target=$TARGET --prefix=$PREFIX --with-newlib --with-isl --disable-multilib --without-libatomic --enable-languages=c,c++,go,fortran,lto --disable-nls --disable-shared --disable-libssp --enable-threads=posix --enable-libgomp --enable-tls --enable-lto --disable-symver && make $NJOBS && make install
+../../gcc/configure --target=$TARGET --prefix=$PREFIX --with-newlib --with-isl --disable-multilib --without-libatomic --enable-languages=c,c++,go,fortran,lto --disable-nls --disable-shared --disable-libssp --enable-threads=posix --enable-libgomp --enable-tls --enable-lto --disable-symver
+make $NJOBS
+make install
 cd -
 fi
 


### PR DESCRIPTION
- change the repo hermit is pulled from to hermit-playground.
- enable libgomp compilation and remove workaround
- enable `set -e`, so we don't miss important errors (else the dependent compilations will produce weird and hard to find errors)

Currently, compiling the toolchain from source fails, since parts of the cmake files for libhermit-rs got moved (?) to hermit-playground. 

What is the reason behind disabling libgomp support in gcc and then trying to install the `libgomp.spec` file? For me this file does not exist with the old gcc flags. I replaced `--disable-libgomp` with `--enable-libgomp`, removed the workaround and everything build fine.

In addition, the toolchain does not build on archlinux with gcc9. This is an upstream binutils issue, there is an unmerged workaround on the [mailing list](https://sourceware.org/legacy-ml/binutils/2019-04/msg00264.html). Currently I have just applied it manually, but since we have forked binutils anyways, we might apply it there aswell?
