### PR TITLE
Downgrade time to 0.3.11

### DIFF
--- a/toolchain.sh
+++ b/toolchain.sh
@@ -41,6 +41,10 @@ fi
 
 if [ ! -d "hermit" ]; then
 git clone --recursive -b master https://github.com/hermitcore/hermit-playground hermit
+pushd hermit/librs
+# See https://github.com/hermitcore/libhermit-rs/issues/597
+cargo update --package time --precise 0.3.11
+popd
 fi
 
 if [ ! -d "newlib" ]; then


### PR DESCRIPTION
See https://github.com/hermitcore/libhermit-rs/issues/597.
Closes https://github.com/hermitcore/hermit-toolchain/issues/25.