### PR TITLE
feat: make `AR`, `CC`, `CXX`, `LD`, `RANLIB` rust target specific

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,13 +145,14 @@ RUN set -eux; \
     make clean
 
 FROM rust:bookworm AS toolchain
+ARG RUST_TARGET
 ARG TARGET
 ARG PREFIX
 COPY --from=gcc $PREFIX $PREFIX
 ENV PATH=$PREFIX/bin:$PATH \
     LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH \
-    AR=$TARGET-ar \
-    CC=$TARGET-gcc \
-    CXX=$TARGET-g++ \
-    LD=$TARGET-ld \
-    RANLIB=$TARGET-ranlib
+    AR_${RUST_TARGET//-/_}=$TARGET-ar \
+    CC_${RUST_TARGET//-/_}=$TARGET-gcc \
+    CXX_${RUST_TARGET//-/_}=$TARGET-g++ \
+    LD_${RUST_TARGET//-/_}=$TARGET-ld \
+    RANLIB_${RUST_TARGET//-/_}=$TARGET-ranlib

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,14 +2,28 @@ target "docker-metadata-action" {}
 
 target "hermit-gcc" {
   matrix = {
-    arch = ["aarch64", "riscv64", "x86_64"]
+    item = [
+      {
+        arch = "aarch64"
+        rust_target = "aarch64-unknown-hermit"
+      },
+      {
+        arch = "riscv64"
+        rust_target = "riscv64gc-unknown-hermit"
+      },
+      {
+        arch = "x86_64"
+        rust_target = "x86_64-unknown-hermit"
+      }
+    ]
   }
   inherits = ["docker-metadata-action"]
-  name = "hermit-gcc-${arch}"
+  name = "hermit-gcc-${item.arch}"
   context = "."
   dockerfile = "Dockerfile"
-  tags = ["ghcr.io/hermit-os/hermit-gcc:${arch}-dev"]
+  tags = ["ghcr.io/hermit-os/hermit-gcc:${item.arch}-dev"]
   args = {
-    ARCH = arch
+    ARCH = item.arch
+    RUST_TARGET = item.rust_target
   }
 }


### PR DESCRIPTION
@jounathaen's [concern](https://github.com/hermit-os/hermit-gcc/pull/57#issuecomment-3184205755) was spot on. With the generic vars set, we cannot compile cargo-careful, for example. Changing the variables to correspond to the respective Rust target should still help with `cc`, but be specific to Hermit.